### PR TITLE
Updated to use CAS Client App instead of CAS Client Auto Config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Bootiful CAS-enabled web application
 
-This is the simplest CASyfied Spring Boot application that there could be. It uses [cas client auto config support](https://github.com/Unicon/cas-client-autoconfig-support)
+This is the simplest CASyfied Spring Boot application that there could be. It uses [official CAS Client](https://github.com/apereo/java-cas-client#spring-boot-autoconfiguration)
 
 It could be used as a template to build more complex CAS-enabled Spring Boot apps, or simply as a quick tester for various CAS servers installations.
 
@@ -9,6 +9,8 @@ It could be used as a template to build more complex CAS-enabled Spring Boot app
 * Make sure you have Java 8 installed (it won't work on Java versions less than 8)
 
 * Clone this repository
+
+* Verify dependency in `build.gradle` for _org.jasig.cas.client:cas-client-support-springboot_ is updated to latest version.
 
 * Change 3 required URL properties in `src/main/resources/application.yml` pointing to the desired CAS server and client host. For example:
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile('org.codehaus.groovy:groovy')
     compile "org.webjars:bootstrap:4.1.3"
 
-    compile('net.unicon.cas:cas-client-autoconfig-support:2.0.0-GA')
+    compile('org.jasig.cas.client:cas-client-support-springboot:3.6.1')
 }
 
 task wrapper(type: Wrapper) {

--- a/src/main/groovy/net/unicon/cas/client/demo/MainController.groovy
+++ b/src/main/groovy/net/unicon/cas/client/demo/MainController.groovy
@@ -1,7 +1,7 @@
 package net.unicon.cas.client.demo
 
-import net.unicon.cas.client.configuration.CasClientConfigurerAdapter
-import net.unicon.cas.client.configuration.EnableCasClient
+import org.jasig.cas.client.boot.configuration.EnableCasClient
+import org.jasig.cas.client.boot.configuration.CasClientConfigurer
 import org.jasig.cas.client.authentication.AttributePrincipal
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.servlet.FilterRegistrationBean
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletResponse
 
 @Controller
 @EnableCasClient
-class MainController extends CasClientConfigurerAdapter {
+class MainController implements CasClientConfigurer {
 
     @Value('${casLogoutUrl}')
     private String casLogoutUrl;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 cas:
   #Required properties
-  server-url-prefix: https://localhost:8143/cas
-  server-login-url: https://localhost:8143/cas/login
-  client-host-url:  https://Axman000.local:8443
+  server-url-prefix: https://dk.example.org:8143/cas
+  server-login-url: https://dk.example.org:8143/cas/login
+  client-host-url: https://dk.example.org:8443
 
   #Optional properties
   authentication-url-patterns: [/protected, /protected2]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 cas:
   #Required properties
-  server-url-prefix: https://dk.example.org:8143/cas
-  server-login-url: https://dk.example.org:8143/cas/login
-  client-host-url: https://dk.example.org:8443
+  server-url-prefix: https://localhost:8143/cas
+  server-login-url: https://localhost:8143/cas/login
+  client-host-url:  https://Axman000.local:8443
 
   #Optional properties
   authentication-url-patterns: [/protected, /protected2]
@@ -37,7 +37,7 @@ server:
     tracking-modes: COOKIE
   ssl:
     enabled: true
-    key-store: /Users/dima767/.keystore
+    key-store: /etc/cas/thekeystore
     key-store-password: changeit
   #For 'renew' param, latest Java CAS client requires that it is set as the Servlet 'context-param'. This is how to easily set it in Spring Boot
   #context-parameters.renew: true


### PR DESCRIPTION
Updated Bootiful CAS client app to use official Java CAS client version 3.6.0 instead of cas:cas-client-autoconfig-support library which has been folded into Java CAS client